### PR TITLE
Update BSA_SubReadOnlyStream.cs

### DIFF
--- a/Assets/Plugins/BetterStreamingAssets/BSA_SubReadOnlyStream.cs
+++ b/Assets/Plugins/BetterStreamingAssets/BSA_SubReadOnlyStream.cs
@@ -116,7 +116,7 @@ namespace Better.StreamingAssets
             {
                 m_position = m_actualStream.Seek(offset, SeekOrigin.Current);
             }
-            return m_position;
+            return m_position - m_offset;
         }
 
         public override void SetLength(long value)


### PR DESCRIPTION
Seek() retuning APK position -> actual stream position to match Stream.Seek() spec.
was causing Assetbundle.LoadFromStream() not to work.